### PR TITLE
fix: add support for perspective for POST requests

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -39,7 +39,7 @@ export class SanityClient<
 
     const url = `https://${this.config.projectId}.${host}/${version}/data/query/${this.config.dataset}`;
 
-    const res = await fetch(`${url}${usePost ? '' : qs}`, {
+    const res = await fetch(`${url}${usePost ? `?perspective=${encodeURIComponent(perspective)}` : qs}`, {
       method: usePost ? 'POST' : 'GET',
       body: usePost ? JSON.stringify({ query, params: params }) : undefined,
       headers,


### PR DESCRIPTION
This PR add support for perspective params in case query uses POST method, by returning it as URL params.